### PR TITLE
use etcher instructions

### DIFF
--- a/artik10.coffee
+++ b/artik10.coffee
@@ -5,6 +5,13 @@ BOARD_SHUTDOWN_ARTIK = 'The device is performing a shutdown. Please wait until t
 SET_JUMPER_SD = 'Set SW2 dip switch to position 1:on, 2:on and then power on the board.'
 SET_JUMPER_EMMC = 'Set SW2 dip switch to position 1:off, 2:off.'
 
+postProvisioningInstructions = [
+	BOARD_SHUTDOWN_ARTIK
+	instructions.REMOVE_INSTALL_MEDIA
+	SET_JUMPER_EMMC
+	instructions.BOARD_REPOWER
+]
+
 module.exports =
 	slug: 'artik10'
 	aliases: [ 'artik10' ]
@@ -13,47 +20,14 @@ module.exports =
 	state: 'preview'
 
 	stateInstructions:
-		postProvisioning: [
-			BOARD_SHUTDOWN_ARTIK
-			instructions.REMOVE_INSTALL_MEDIA
-			SET_JUMPER_EMMC
-			instructions.BOARD_REPOWER
-		]
+		postProvisioning: postProvisioningInstructions
 
-	instructions:
-		windows: [
-			instructions.WINDOWS_DISK_IMAGER_SD
-			instructions.EJECT_SD
-			instructions.FLASHER_WARNING
-			SET_JUMPER_SD
-			BOARD_SHUTDOWN_ARTIK
-			instructions.REMOVE_INSTALL_MEDIA
-			SET_JUMPER_EMMC
-			instructions.BOARD_REPOWER
-		]
-		osx: [
-			instructions.OSX_PLUG_SD
-			instructions.OSX_UNMOUNT_SD
-			instructions.DD_BURN_IMAGE_SD
-			instructions.EJECT_SD
-			instructions.FLASHER_WARNING
-			SET_JUMPER_SD
-			BOARD_SHUTDOWN_ARTIK
-			instructions.REMOVE_INSTALL_MEDIA
-			SET_JUMPER_EMMC
-			instructions.BOARD_REPOWER
-		]
-		linux: [
-			instructions.LINUX_DF_SD
-			instructions.DD_BURN_IMAGE_SD
-			instructions.EJECT_SD
-			instructions.FLASHER_WARNING
-			SET_JUMPER_SD
-			BOARD_SHUTDOWN_ARTIK
-			instructions.REMOVE_INSTALL_MEDIA
-			SET_JUMPER_EMMC
-			instructions.BOARD_REPOWER
-		]
+	instructions: [
+		instructions.ETCHER_SD
+		instructions.EJECT_SD
+		instructions.FLASHER_WARNING
+		SET_JUMPER_SD
+	].concat(postProvisioningInstructions)
 
 	gettingStartedLink:
 		windows: 'http://docs.resin.io/#/pages/installing/gettingStarted-Samsung-Artik10.md#windows'

--- a/artik5.coffee
+++ b/artik5.coffee
@@ -5,6 +5,13 @@ BOARD_SHUTDOWN_ARTIK = 'The device is performing a shutdown. Please wait until t
 SET_JUMPER_SD = 'Set SW2 dip switch to position 1:off, 2:on and then power on the board.'
 SET_JUMPER_EMMC = 'Set SW2 dip switch to position 1:off, 2:off.'
 
+postProvisioningInstructions = [
+	BOARD_SHUTDOWN_ARTIK
+	instructions.REMOVE_INSTALL_MEDIA
+	SET_JUMPER_EMMC
+	instructions.BOARD_REPOWER
+]
+
 module.exports =
 	slug: 'artik5'
 	aliases: [ 'artik5' ]
@@ -13,47 +20,14 @@ module.exports =
 	state: 'preview'
 
 	stateInstructions:
-		postProvisioning: [
-			BOARD_SHUTDOWN_ARTIK
-			instructions.REMOVE_INSTALL_MEDIA
-			SET_JUMPER_EMMC
-			instructions.BOARD_REPOWER
-		]
+		postProvisioning: postProvisioningInstructions
 
-	instructions:
-		windows: [
-			instructions.WINDOWS_DISK_IMAGER_SD
-			instructions.EJECT_SD
-			instructions.FLASHER_WARNING
-			SET_JUMPER_SD
-			BOARD_SHUTDOWN_ARTIK
-			instructions.REMOVE_INSTALL_MEDIA
-			SET_JUMPER_EMMC
-			instructions.BOARD_REPOWER
-		]
-		osx: [
-			instructions.OSX_PLUG_SD
-			instructions.OSX_UNMOUNT_SD
-			instructions.DD_BURN_IMAGE_SD
-			instructions.EJECT_SD
-			instructions.FLASHER_WARNING
-			SET_JUMPER_SD
-			BOARD_SHUTDOWN_ARTIK
-			instructions.REMOVE_INSTALL_MEDIA
-			SET_JUMPER_EMMC
-			instructions.BOARD_REPOWER
-		]
-		linux: [
-			instructions.LINUX_DF_SD
-			instructions.DD_BURN_IMAGE_SD
-			instructions.EJECT_SD
-			instructions.FLASHER_WARNING
-			SET_JUMPER_SD
-			BOARD_SHUTDOWN_ARTIK
-			instructions.REMOVE_INSTALL_MEDIA
-			SET_JUMPER_EMMC
-			instructions.BOARD_REPOWER
-		]
+	instructions: [
+		instructions.ETCHER_SD
+		instructions.EJECT_SD
+		instructions.FLASHER_WARNING
+		SET_JUMPER_SD
+	].concat(postProvisioningInstructions)
 
 	gettingStartedLink:
 		windows: 'http://docs.resin.io/#/pages/installing/gettingStarted-Samsung-Artik5.md#windows'


### PR DESCRIPTION
This makes the instructions use Etcher as primary image burning software.

To make it work: (from @emirotin) 
1. approve and merge resin-io/resin-device-types#7
2. update the resin-device-types submodule in this branch and update this PR
3. test how the JSON file is built (I've tested it myself by checking out the corresponding branch in a submodule)
4. approve and merge this PR
5. follow the standard procedure to release this device type and get it to img-maker
