### PR TITLE
artik10: Enable host mode at boot up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+Change log
+-----------
+
+* Switch usb3 to host mode on system boot [Florin]

--- a/layers/meta-resin-artik/recipes-support/resin-init/resin-init-board.bbappend
+++ b/layers/meta-resin-artik/recipes-support/resin-init/resin-init-board.bbappend
@@ -1,0 +1,1 @@
+FILESEXTRAPATHS_append_artik10 := "${THISDIR}/${PN}"

--- a/layers/meta-resin-artik/recipes-support/resin-init/resin-init-board/resin-init-board
+++ b/layers/meta-resin-artik/recipes-support/resin-init/resin-init-board/resin-init-board
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+set -e
+
+echo "Setting USB 3.0 port to host mode"
+echo 0 > /sys/devices/usb.1/12000000.dwc3/id
+
+exit 0


### PR DESCRIPTION
This enables us to use an eth to usb adapter for example so we have
networking through the usb3 port on the artik10 devel board.

Signed-off-by: Florin Sarbu florin@resin.io
