### PR TITLE
local.conf.sample: Have build information on the target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Change log
 -----------
 
+* Add build information in the target rootfs [Florin]
+
 # v1.1.3 - 2016-04-14
 
 * Add oe-meta-go to submodules and BBLAYERS [Andrei]

--- a/layers/meta-resin-artik/conf/samples/local.conf.sample
+++ b/layers/meta-resin-artik/conf/samples/local.conf.sample
@@ -32,6 +32,9 @@ DISTRO ?= "resin-systemd"
 # http://www.yoctoproject.org/docs/latest/mega-manual/mega-manual.html#ref-classes-rm-work
 #INHERIT += "rm_work"
 
+# have build information available on the target under /etc/build
+INHERIT += "image-buildinfo"
+
 # Package Management configuration
 PACKAGE_CLASSES ?= "package_rpm"
 


### PR DESCRIPTION
By adding this to the .conf file, we will have build information on the target
available in the /etc/build file. This file contains info such as:
## root@artik10:~# cat /etc/build

| Build Configuration: |
| --- |

DISTRO = resin-os
## DISTRO_VERSION = 1.1.3

| Layer Revisions: |
| --- |

meta              = HEAD:b1f23d1254682866236bfaeb843c0d8aa332efc2
meta-yocto        = HEAD:b1f23d1254682866236bfaeb843c0d8aa332efc2
meta-oe           = HEAD:dc5634968b270dde250690609f0015f881db81f2
meta-networking   = HEAD:dc5634968b270dde250690609f0015f881db81f2
meta-python       = HEAD:dc5634968b270dde250690609f0015f881db81f2
meta-artik        = fix_btrfs_skinny_relocation:cae2b1e95e2416bff37e1c24404fceabba6e3692
meta-resin-common = HEAD:b89759e1c0e7d3d3cef92d662ba9441eae79d890
meta-resin-jethro = HEAD:b89759e1c0e7d3d3cef92d662ba9441eae79d890
meta-resin-artik  = master:67b912873c3c784d765068f9b507c0fb99583fcc -- modified
oe-meta-go        = HEAD:07581eadebdcf804a6e422fc9bf6dfe97dc5b0b8

Signed-off-by: Florin Sarbu florin@resin.io
