### PR TITLE
Custom docker images in connectable builds on resin-artik

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Change log
 -----------
 
+* Custom docker images in connectable builds [Andrei]
 * Bump meta-resin to include connectable builds [Andrei]
 * Add support for optional supervisor image [Andrei]
 * Update meta-resin to v1.2 [Andrei]

--- a/layers/meta-resin-artik/recipes-containers/docker-disk/docker-resin-supervisor-disk.bbappend
+++ b/layers/meta-resin-artik/recipes-containers/docker-disk/docker-resin-supervisor-disk.bbappend
@@ -1,4 +1,4 @@
 # common for both Artik 5 and Artik 10
 
-TARGET_REPOSITORY = "resin/armv7hf-supervisor"
+SUPERVISOR_REPOSITORY = "resin/armv7hf-supervisor"
 LED_FILE = "/dev/null"


### PR DESCRIPTION
Connects to resin-os/meta-resin#133-supervisor-custom-image-tag
@telphan @floion
