### PR TITLE
kernel-modules-headers.bbappend: Add patch for removing the

### DIFF
--- a/layers/meta-resin-artik/recipes-devtools/kernel-modules-headers/kernel-modules-headers.bbappend
+++ b/layers/meta-resin-artik/recipes-devtools/kernel-modules-headers/kernel-modules-headers.bbappend
@@ -1,0 +1,3 @@
+FILESEXTRAPATHS_append := ":${THISDIR}/${PN}"
+
+SRC_URI_append = " file://in_tree_build.patch"

--- a/layers/meta-resin-artik/recipes-devtools/kernel-modules-headers/kernel-modules-headers/in_tree_build.patch
+++ b/layers/meta-resin-artik/recipes-devtools/kernel-modules-headers/kernel-modules-headers/in_tree_build.patch
@@ -1,0 +1,43 @@
+When trying to build using "make O=" in a kernel source tree which is not clean,
+we will encounter an error because of this sanity check in the kernel's top level Makefile:
+
+# prepare3 is used to check if we are building in a separate output directory,
+# and if so do:
+# 1) Check that make has not been executed in the kernel src $(srctree)
+
+ifneq ($(KBUILD_SRC),)
+	@$(kecho) '  Using $(srctree) as source for kernel'
+	$(Q)if [ -f $(srctree)/.config -o -d $(srctree)/include/config ]; then \
+		echo >&2 "  $(srctree) is not clean, please run 'make mrproper'"; \
+		echo >&2 "  in the '$(srctree)' directory.";\
+		/bin/false; \
+	fi;
+endif
+
+Upstream-Status: Inappropriate [configuration specific]
+
+Signed-off-by: Florin Sarbu <florin@resin.io>
+
+Index: git/gen_mod_headers
+===================================================================
+--- git.orig/gen_mod_headers
++++ git/gen_mod_headers
+@@ -63,9 +63,6 @@ target_karch_dir="$target_dir/$karch_dir
+ [[ -f "${obj_dir}/.config" ]] || fatal "Missing kernel configuration."
+ [[ -f "${obj_dir}/Module.symvers" ]] || fatal "Missing Module.symvers."
+ 
+-# Copy in .config and Module.symvers so we can specify O=$target_dir.
+-cp "${obj_dir}/.config" "${obj_dir}/Module.symvers" "$target_dir"
+-
+ extra_header_dirs="drivers/md net/mac80211 drivers/media/dvb-core include/config/dvb \
+ drivers/media/dvb-frontends drivers/media/usb/dvb-usb drivers/media/tuners"
+ 
+@@ -75,7 +72,7 @@ trap pop EXIT
+ [[ -d "$karch_dir" ]] || fatal "Unrecognised karch: $karch"
+ 
+ echo Running modules_prepare...
+-make O="$target_dir" $build_opts modules_prepare
++make $build_opts modules_prepare
+ 
+ echo Copying required files...
+ 


### PR DESCRIPTION
option to have the script output in a different directory.

Because we cannot use "make O=" with an un-clean kernel source tree
(such as for the artik boards) we need to patch the kernel modules header
generation script to remove this option from make.

Signed-off-by: Florin Sarbu florin@resin.io
