### PR TITLE
Disable mac address randomization in network manager (for both artik5 and artik10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Change log
 -----------
 
+* Add entry for the disabling of random MAC address generation when scanning for a WiFi connection [Florin]
 * Add backported patch for making aufs work on the smack enabled kernel of artik5 and artik10 [Florin]
 
 # v2.0.0-beta11.rev1 - 2017-02-15

--- a/layers/meta-resin-artik/recipes-connectivity/networkmanager/networkmanager_%.bbappend
+++ b/layers/meta-resin-artik/recipes-connectivity/networkmanager/networkmanager_%.bbappend
@@ -1,0 +1,8 @@
+do_install_append() {
+    # don't enable random mac address generation when scanning for WiFi (on both the artik5 and artik10)
+    cat >> ${D}${sysconfdir}/NetworkManager/NetworkManager.conf <<EOF
+
+[device]
+wifi.scan-rand-mac-address=no
+EOF
+}


### PR DESCRIPTION
This fixes the issue on artik10 when sometimes it takes 10-15 minutes or more to be able to get an IP address. During this time, the following can be observed in journalctl for NetworkManager (it fills the journal basically with these messages):

Feb 17 08:40:54 705ada7 NetworkManager[3758]: <warn>  [1487320854.6742] device (wlan0): set-hw-addr: new MAC address C2:83:79:9E:60:2C not successfully set (scanning)
Feb 17 08:40:54 705ada7 NetworkManager[3758]: <info>  [1487320854.7465] device (wlan0): supplicant interface state: inactive -> disabled
Feb 17 08:40:54 705ada7 NetworkManager[3758]: <info>  [1487320854.8043] device (wlan0): supplicant interface state: disabled -> inactive
Feb 17 08:40:54 705ada7 NetworkManager[3758]: <warn>  [1487320854.9377] device (wlan0): set-hw-addr: new MAC address C2:83:79:9E:60:2C not successfully set (scanning)
Feb 17 08:40:55 705ada7 NetworkManager[3758]: <info>  [1487320855.0071] device (wlan0): supplicant interface state: inactive -> disabled
Feb 17 08:40:55 705ada7 NetworkManager[3758]: <info>  [1487320855.0640] device (wlan0): supplicant interface state: disabled -> inactive
Feb 17 08:40:55 705ada7 NetworkManager[3758]: <warn>  [1487320855.1807] device (wlan0): set-hw-addr: new MAC address C2:83:79:9E:60:2C not successfully set (scanning)
Feb 17 08:40:55 705ada7 NetworkManager[3758]: <info>  [1487320855.2189] device (wlan0): supplicant interface state: inactive -> disabled
Feb 17 08:40:55 705ada7 NetworkManager[3758]: <info>  [1487320855.2814] device (wlan0): supplicant interface state: disabled -> inactive
Feb 17 08:40:55 705ada7 NetworkManager[3758]: <warn>  [1487320855.3935] device (wlan0): set-hw-addr: new MAC address C2:83:79:9E:60:2C not successfully set (scanning)
Feb 17 08:40:55 705ada7 NetworkManager[3758]: <info>  [1487320855.4665] device (wlan0): supplicant interface state: inactive -> disabled

For the artik5, it only takes 5-10 seconds (or around that) to get an IP, however these messages can be seen in journalctl also, although just a few occurrences.