### PR TITLE
cover the swap process between eval and kitra carrier during provisio…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Change log
 -----------
 
+* Modify kitra520.coffee instructions for booting off the provisioned eMMC [Carlo]
+
 # v2.0.4+rev3 - 2017-05-26
 
 * Add kitra520.coffee file [Florin]

--- a/kitra520.coffee
+++ b/kitra520.coffee
@@ -3,8 +3,8 @@ deviceTypesCommon = require '@resin.io/device-types/common'
 
 BOARD_SHUTDOWN_ARTIK = 'The device has performed a shutdown. Press the power switch PWR SW to the off position.'
 SET_JUMPER_SD = 'Set SW2 dip switch to position 1:on, 2:on.  Also, make sure jumpers J20 and J33 are set towards the edge of the board.'
-SET_JUMPER_EMMC = 'Set SW2 dip switch to position 1:off, 2:off.'
-BOARD_POWERON_ARTIK = 'Press the power switch PWR SW to the on position. Press and hold for 1 second the SW3 POWER push button.'
+SET_JUMPER_EMMC = 'Remove the Artik520 module from the evaluation carrier and plug it on the Kitra520 carrier.'
+BOARD_POWERON_ARTIK = 'Press and hold the power button PB1 - PB2 until you hear a double buzz sound.'
 
 postProvisioningInstructions = [
 	BOARD_SHUTDOWN_ARTIK


### PR DESCRIPTION
since resinOS does not support fastboot flashing, the user needs to swap between the artik520 evaluation carrier board and the kitra520 carrier board. This PR attempts to address that process