### PR TITLE
hostapp-update-hooks:99-flash-bootloader-artik533s: Fix typo

### DIFF
--- a/layers/meta-resin-artik/recipes-support/hostapp-update-hooks/files/99-flash-bootloader-artik533s
+++ b/layers/meta-resin-artik/recipes-support/hostapp-update-hooks/files/99-flash-bootloader-artik533s
@@ -38,7 +38,7 @@ uboot_skip_blocks=0
 secureos_file="secureos.img"
 secureos_block_size=512
 # count here should be bigger than the actual file so count actually won't matter
-secureos_cound=100000000
+secureos_count=100000000
 secureos_seek_blocks=769
 secureos_skip_blocks=0
 


### PR DESCRIPTION
Changelog-entry: Fix typo in 99-flash-bootloader-artik533s
Signed-off-by: Florin Sarbu <florin@balena.io>