### PR TITLE
kernel-modules-headers: Remove AARCH64 binaries to pass QA checks

### DIFF
--- a/layers/meta-resin-artik/recipes-devtools/kernel-modules-headers/kernel-modules-headers.bbappend
+++ b/layers/meta-resin-artik/recipes-devtools/kernel-modules-headers/kernel-modules-headers.bbappend
@@ -1,0 +1,6 @@
+do_install_append () {
+    # Remove precompiled AARCH64 binaries inherited from the kernel git tree.
+    # These are still part of the tarball. But removed from the package
+    # as we use the package infrastructure for QA checks
+    rm -f "${D}/usr/src/kernel-hdrs/drivers/input/touchscreen/gsl_point_id_64"
+}


### PR DESCRIPTION
In meta-balena, arch checks have been added to all binaries going in the
kernel-modules-headers tarball. These binaries are inherited from the
kernel git tree. They are compiled for AARCH64 and trigger QA arch errors.
Remove them from the package. They are still included in the tarball.
Just removed from the package infrastructure. We don't use the ipk
file for anything other than QA checks

Change-type: patch
Changelog-entry: Fixup kernel-modules-headers qa checks
Signed-off-by: Zubair Lutfullah Kakakhel <zubair@balena.io>