### PR TITLE
resin-init/resin-init-board: Add i2c-1 device from overlay

### DIFF
--- a/layers/meta-resin-artik/recipes-support/resin-init/resin-init-board.bbappend
+++ b/layers/meta-resin-artik/recipes-support/resin-init/resin-init-board.bbappend
@@ -4,10 +4,12 @@ FILESEXTRAPATHS_append_artik53x := ":${THISDIR}/${PN}"
 SRC_URI_append_artik53x = " \
     file://resin-init-board \
     file://resin-530s-spidev \
+    file://resin-530s-i2c1 \
 "
 do_install_artik53x() {
     install -d ${D}${bindir}
     install -m 0755 ${WORKDIR}/resin-530s-spidev ${D}${bindir}
+    install -m 0755 ${WORKDIR}/resin-530s-i2c1 ${D}${bindir}
     install -m 0755 ${WORKDIR}/resin-init-board ${D}${bindir}
 }
 

--- a/layers/meta-resin-artik/recipes-support/resin-init/resin-init-board/resin-530s-i2c1
+++ b/layers/meta-resin-artik/recipes-support/resin-init/resin-init-board/resin-530s-i2c1
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -e
+
+echo "Appling overlay for i2c device i2c-1"
+mount -o remount,rw /
+test ! -d /sys/kernel/config/device-tree/overlays/i2c1 && mkdir /sys/kernel/config/device-tree/overlays/i2c1
+cd /mnt/boot/overlays
+cat s5p4418-artik533-compy-i2c1.dtbo > /sys/kernel/config/device-tree/overlays/i2c1/dtbo
+mount -o remount,ro /
+exit 0

--- a/layers/meta-resin-artik/recipes-support/resin-init/resin-init-board/resin-init-board
+++ b/layers/meta-resin-artik/recipes-support/resin-init/resin-init-board/resin-init-board
@@ -6,5 +6,6 @@ echo "Setting USB 3.0 port to host mode"
 test -e /sys/devices/usb.1/12000000.dwc3/id && echo 0 > /sys/devices/usb.1/12000000.dwc3/id
 
 test -e /usr/bin/resin-530s-spidev && /usr/bin/resin-530s-spidev
+test -e /usr/bin/resin-530s-i2c1 && /usr/bin/resin-530s-i2c1
 
 exit 0


### PR DESCRIPTION
Similar to the spidev, a shell script was added to enable
the i2c-1 device in /dev. This change is for the artik530s
board.

Changelog-entry: Added i2c-1 dev from overlay for 530s
Signed-off-by: Vicentiu Galanopulo <vicentiu@resin.io>