### PR TITLE
networkmanager_%.bbappend: Set eth* interfaces unmanaged

### DIFF
--- a/layers/meta-balena-artik/recipes-connectivity/networkmanager/networkmanager_%.bbappend
+++ b/layers/meta-balena-artik/recipes-connectivity/networkmanager/networkmanager_%.bbappend
@@ -6,6 +6,6 @@ do_install_append() {
 wifi.scan-rand-mac-address=no
 
 [keyfile]
-unmanaged-devices=interface-name:p2p*
+unmanaged-devices=interface-name:p2p*;interface-name:eth*
 EOF
 }


### PR DESCRIPTION
The ethernet interface does not exist on the customer
board but it is enumerated in the device tree.
This results in a flood of dmesg errors from the networking stack
[ 1363.113000] stmmac_hw_setup DMA engine initialization failed
[ 1363.119000] stmmac_open Hw setup failed

Changelog-entry: Remove NetworkManger management for ethernet interfaces
Signed-off-by: Vicentiu Galanopulo <vicentiu@balena.io>